### PR TITLE
added 'skip_cleanup' handling to CPAN::Mini::Inject::update_mirror

### DIFF
--- a/lib/CPAN/Mini/Inject.pm
+++ b/lib/CPAN/Mini/Inject.pm
@@ -224,6 +224,7 @@ sub update_mirror {
   $options{local}     ||= $self->config->get( 'local' );
   $options{trace}     ||= 0;
   $options{skip_perl} ||= $self->config->get( 'perl' ) || 1;
+  $options{skip_cleanup} ||= $self->config->get( 'skip_cleanup' ) || 0;
 
   $self->testremote( $options{trace} )
    unless ( $self->site || $options{remote} );


### PR DESCRIPTION
Hi Andy-

CPAN::Mini supports the 'skip_cleanup' flag.  In this commit, I add handling for passing 'skip_cleanup' through from the mcpani configuration via CPAN::Mini::Inject::update_mirror to CPAN::Mini.  I'm using this internally, and it's working for me.  What do you think?

thanks-

Matt Lanier
