### PR TITLE
Fixed RT 87144.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -9,6 +9,7 @@ META.json
 META.yml
 README
 t/.mcpani/config
+t/.mcpani/config_with_whitespaces
 t/.mcpani/config_bad
 t/.mcpani/config_badremote
 t/.mcpani/config_mcpi

--- a/lib/CPAN/Mini/Inject/Config.pm
+++ b/lib/CPAN/Mini/Inject/Config.pm
@@ -159,7 +159,7 @@ sub parse_config {
 
     while ( <$fh> ) {
       next if /^\s*#/;
-      $self->{$1} = $2 if /([^:\s]+)\s*:\s*(.*)$/;
+      $self->{$1} = $2 if /^\s*([^:\s]+)\s*:\s*(.*?)\s*$/;
       delete $required{$1} if defined $required{$1};
     }
 

--- a/t/.mcpani/config_with_whitespaces
+++ b/t/.mcpani/config_with_whitespaces
@@ -1,0 +1,6 @@
+  # all config lines with trailing whitespaces
+  local      :   t/local/CPAN    
+  remote     :  http://localhost:11027   
+  repository :  t/local/MYCPAN   
+  dirmode   :   0775  
+  passive    :  yes                               

--- a/t/parsecfg.t
+++ b/t/parsecfg.t
@@ -1,4 +1,4 @@
-use Test::More tests => 6;
+use Test::More tests => 11;
 
 use CPAN::Mini::Inject;
 
@@ -14,3 +14,12 @@ $mcpi->parsecfg( 't/.mcpani/config' );
 is( $mcpi->{config}{local},      't/local/CPAN' );
 is( $mcpi->{config}{remote},     'http://localhost:11027' );
 is( $mcpi->{config}{repository}, 't/local/MYCPAN' );
+
+
+$mcpi = CPAN::Mini::Inject->new;
+$mcpi->parsecfg( 't/.mcpani/config_with_whitespaces' );
+is( $mcpi->{config}{local},      't/local/CPAN' );
+is( $mcpi->{config}{remote},     'http://localhost:11027' );
+is( $mcpi->{config}{repository}, 't/local/MYCPAN' );
+is( $mcpi->{config}{dirmode},    '0775' );
+is( $mcpi->{config}{passive},    'yes' );


### PR DESCRIPTION
No trailing whitespaces for config values anymore.

I reported the bug at the CPAN bug tracker some days ago and fixed it now. Notified Christian Walde of the fix.
