### PR TITLE
t/update_mirror.t: Ignore DIE signal inside eval blocks

### DIFF
--- a/t/update_mirror.t
+++ b/t/update_mirror.t
@@ -24,7 +24,10 @@ my $pid    = $server->background;
 ok( $pid, 'HTTP Server started' );
 sleep 1;
 
-$SIG{__DIE__} = sub { kill( 9, $pid ) };
+$SIG{__DIE__} = sub {
+  return if $^S; # ignore die in an eval block, while process is still running
+  kill( 9, $pid )
+};
 
 my $mcpi = CPAN::Mini::Inject->new;
 $mcpi->parsecfg( 't/.mcpani/config' );


### PR DESCRIPTION
The process will still be running and the error handled.
See: https://www.perlmonks.org/?node_id=1173708

This leads to situations where the test server is stopped and tests failing,
due to the "libregexp-ipv6-perl" not being installed in Debian/Ubuntu.

It's caused by liburi-perl's detection of "Regexp::IPv6" by requiring it and
catching the failure (DIE signal) in URI/_generic.pm:20.
https://github.com/libwww-perl/URI/blob/master/lib/URI/_generic.pm#L20

Signed-off-by: Lukas Märdian <slyon@ubuntu.com>